### PR TITLE
`supports_index_sort_order?` should return `false`

### DIFF
--- a/lib/active_record/connection_adapters/tidb_adapter.rb
+++ b/lib/active_record/connection_adapters/tidb_adapter.rb
@@ -62,8 +62,8 @@ module ActiveRecord
       end
 
       def supports_index_sort_order?
-        # TODO: check TiDB version
-        true
+        # https://github.com/pingcap/tidb/issues/2519 support is required
+        false
       end
 
       def supports_expression_index?


### PR DESCRIPTION
This pull request changes `supports_index_sort_order?` return value because TiDB does not support descending index yet  until pingcap/tidb#2519 is implemented.

Fix #16

