### PR TITLE
Move `transaction_isolation_levels` to `database_statements.rb`

### DIFF
--- a/lib/active_record/connection_adapters/tidb/database_statements.rb
+++ b/lib/active_record/connection_adapters/tidb/database_statements.rb
@@ -15,4 +15,11 @@ ActiveRecord::ConnectionAdapters::DatabaseStatements.class_eval do
     end
   end
   alias create insert
+
+  def transaction_isolation_levels
+    {
+      read_committed: 'READ COMMITTED',
+      repeatable_read: 'REPEATABLE READ'
+     }
+   end
 end

--- a/lib/active_record/connection_adapters/tidb_adapter.rb
+++ b/lib/active_record/connection_adapters/tidb_adapter.rb
@@ -74,13 +74,6 @@ module ActiveRecord
         tidb_version >= '5.1.0'
       end
 
-      def transaction_isolation_levels
-        {
-          read_committed: 'READ COMMITTED',
-          repeatable_read: 'REPEATABLE READ'
-        }
-      end
-
       def initialize(connection, logger, conn_params, config)
         super(connection, logger, conn_params, config)
 


### PR DESCRIPTION
This commit defines TiDB own `transaction_isolation_levels` to allow `:read_committed` and `:repeatable_read`

Active Record supports for specifying transaction isolation level.

```ruby
  Post.transaction(isolation: :repeatable_read) do
    # ...
  end
```

`mysql2` adapter inherits `transaction_isolation_levels` from Abstract adapter
then it allows users to specify these isolation levels.

    * `:read_uncommitted`
    * `:read_committed`
    * `:repeatable_read`
    * `:serializable`

However, TiDB does not support `READ UNCOMMITTED` and `SERIALIZABLE` as follows.
setting `tidb_skip_isolation_level_check=1` just skip this error and it works as no-op.
then ActiveRecord TiDB Adapter should not have these two isolation levels.

    - Supported isolation level with this commit
    * `:read_committed`
    * `:repeatable_read`

```sql
Server version: 5.7.25-TiDB-v5.2.0 TiDB Server (Apache License 2.0) Community Edition, MySQL 5.7 compatible
... snip ...
mysql> SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
ERROR 8048 (HY000): The isolation level 'READ-UNCOMMITTED' is not supported. Set tidb_skip_isolation_level_check=1 to skip this error
mysql> SET TRANSACTION ISOLATION LEVEL READ COMMITTED;
Query OK, 0 rows affected (0.00 sec)

mysql> SET TRANSACTION ISOLATION LEVEL REPEATABLE READ;
Query OK, 0 rows affected (0.00 sec)

mysql> SET TRANSACTION ISOLATION LEVEL SERIALIZABLE;
ERROR 8048 (HY000): The isolation level 'SERIALIZABLE' is not supported. Set tidb_skip_isolation_level_check=1 to skip this error
```

Refer
https://github.com/rails/rails/commit/392eeecc11a291e406db927a18b75f41b2658253