### PR TITLE
Run TiDB 5.2.0 at CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,24 @@ on:
       - 'docs/**'
 
 jobs:
+  tidb520:
+    if: ${{ !contains(github.event.commits[0].message, '[skip ci]') }}
+    runs-on: ubuntu-latest
+    services:
+      tidb:
+        image: hooopo/tidb-playground:v5.2.0
+        env:
+          TIDB_VERSION: v5.2.0
+        ports: ["4000:4000"]
+    steps:
+    - uses: actions/checkout@v2
+    - uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: 2.7
+        bundler-cache: true
+    - run: sleep 30 && MYSQL_USER=root MYSQL_HOST=127.0.0.1 MYSQL_PORT=4000 tidb=1 ARCONN=tidb bundle exec rake db:tidb:build
+    - run: sleep 10 && MYSQL_USER=root MYSQL_HOST=127.0.0.1 MYSQL_PORT=4000 tidb=1 ARCONN=tidb bundle exec rake test:tidb
+
   tidb510:
     if: ${{ !contains(github.event.commits[0].message, '[skip ci]') }}
     runs-on: ubuntu-latest


### PR DESCRIPTION
This pull request runs TiDB 5.2.0 at CI.

- TiDB 5.2.0 has been released on Aug 27, 2021.
https://docs.pingcap.com/zh/tidb/stable/release-5.2.0

- `hooopo/tidb-playground:v5.2.0` is available at Docker Hub
https://hub.docker.com/layers/hooopo/tidb-playground/v5.2.0/images/sha256-78ba54d7098635fd1d29b7f41ad1030d98c4a720ae97d4d680e08611caf93fa6?context=explore