### PR TITLE
Rails 7 requires Ruby 2.7

### DIFF
--- a/activerecord-tidb-adapter.gemspec
+++ b/activerecord-tidb-adapter.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.description   = 'Allows the use of TiDB as a backend for ActiveRecord and Rails apps.'
   spec.homepage      = 'https://github.com/pingcap/activerecord-tidb-adapter'
   spec.license       = 'Apache-2.0'
-  spec.required_ruby_version = '>= 2.4.0'
+  spec.required_ruby_version = '>= 2.7.0'
 
   # spec.metadata["allowed_push_host"] = "TODO: Set to 'https://mygemserver.com'"
 


### PR DESCRIPTION
This pull request bumps the required_ruby_version to 2.7 because Rails main branch which will be released as Rails 7 does .

Refer
https://github.com/rails/rails/commit/6487836af8f50648a9b30ce61864c827132e5592