### PR TITLE
Rails 6 requires Ruby 2.5

### DIFF
--- a/activerecord-tidb-adapter.gemspec
+++ b/activerecord-tidb-adapter.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.description   = 'Allows the use of TiDB as a backend for ActiveRecord and Rails apps.'
   spec.homepage      = 'https://github.com/pingcap/activerecord-tidb-adapter'
   spec.license       = 'Apache-2.0'
-  spec.required_ruby_version = '>= 2.4.0'
+  spec.required_ruby_version = '>= 2.5.0'
 
   # spec.metadata["allowed_push_host"] = "TODO: Set to 'https://mygemserver.com'"
 


### PR DESCRIPTION
Similar pull request as #21, this pull request bumps
the required ruby version to Ruby 2.5 for 6-1-stable branch.

Refer https://github.com/rails/rails/pull/34754