### PR TITLE
`self.use_transactional_tests = false` for all test cases

### DIFF
--- a/test/cases/test_case.rb
+++ b/test/cases/test_case.rb
@@ -1,0 +1,5 @@
+module ActiveRecord
+  class TestCase < ActiveSupport::TestCase #:nodoc:
+    self.use_transactional_tests = false
+  end
+end


### PR DESCRIPTION
Active Record test case depends on database savepoint feature to restore the database status by default as `self.use_transactional_tests = true`

As of TiDB 5.2, it does not support savepoint feature yet then
changing `self.use_transactional_tests = false` for all test cases until it is
implemented.

Refer
https://github.com/pingcap/tidb/issues/6840