### PR TITLE
Add `x86_64-darwin-20` to allow macOS Big Sur

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -174,6 +174,7 @@ GEM
 
 PLATFORMS
   x86_64-darwin-18
+  x86_64-darwin-20
   x86_64-linux
 
 DEPENDENCIES


### PR DESCRIPTION
This pull request adds `x86_64-darwin-20` to allow macOS Big Sur.

```
% uname -a
Darwin yahondambp.local 20.6.0 Darwin Kernel Version 20.6.0: Wed Jun 23 00:26:31 PDT 2021; root:xnu-7195.141.2~5/RELEASE_X86_64 x86_64
% sw_vers -productVersion
11.5.2
```

* bundle install to add
```
% bundle install
Warning: the running version of Bundler (2.2.22) is older than the version that created the lockfile (2.2.25). We suggest you to upgrade to the version that created the lockfile by running `gem install bundler:2.2.25`.
Fetching gem metadata from https://rubygems.org/.........
Resolving dependencies...
... snip ...
Use `bundle info [gemname]` to see where a bundled gem is installed.
```

* git diff
```
diff --git a/Gemfile.lock b/Gemfile.lock
index dd89fb0..82094ce 100644
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -174,6 +174,7 @@ GEM

 PLATFORMS
   x86_64-darwin-18
+  x86_64-darwin-20
   x86_64-linux

 DEPENDENCIES
```