### PR TITLE
Explain why `supports_bulk_alter?` returns false

### DIFF
--- a/lib/active_record/connection_adapters/tidb_adapter.rb
+++ b/lib/active_record/connection_adapters/tidb_adapter.rb
@@ -46,6 +46,7 @@ module ActiveRecord
       end
 
       def supports_bulk_alter?
+        # https://github.com/pingcap/tidb/issues/14766 support is required
         false
       end
 


### PR DESCRIPTION
This pull request add a comment to explain why `supports_bulk_alter?` returns false.

Related to https://github.com/pingcap/rails/pull/4 , which requests to remove the link to https://github.com/pingcap/tidb/issues/14766