### PR TITLE
Add links to explain why these methods return false

### DIFF
--- a/lib/active_record/connection_adapters/tidb_adapter.rb
+++ b/lib/active_record/connection_adapters/tidb_adapter.rb
@@ -38,10 +38,12 @@ module ActiveRecord
       ADAPTER_NAME = 'Tidb'
 
       def supports_savepoints?
+        # https://github.com/pingcap/tidb/issues/6840 support is required
         false
       end
 
       def supports_foreign_keys?
+        # https://github.com/pingcap/tidb/issues/18209 support is required
         false
       end
 
@@ -51,6 +53,7 @@ module ActiveRecord
       end
 
       def supports_advisory_locks?
+        # https://github.com/pingcap/tidb/issues/14994 support is required
         false
       end
 


### PR DESCRIPTION
This pull request adds links to explain why these methods return false.

Refer these issues for details
https://github.com/pingcap/tidb/issues/6840
https://github.com/pingcap/tidb/issues/18209
https://github.com/pingcap/tidb/issues/14994

This will also create back links from these issues then it would help to understand why these features are required. Also once these linked issue are closed as resolved we can remove these methods to use mysql2 ones.