### PR TITLE
Use official `pingcap/tidb` Docker images for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,14 +55,14 @@ jobs:
     - run: sleep 30 && MYSQL_USER=root MYSQL_HOST=127.0.0.1 MYSQL_PORT=4000 tidb=1 ARCONN=tidb bundle exec rake db:tidb:build
     - run: sleep 10 && MYSQL_USER=root MYSQL_HOST=127.0.0.1 MYSQL_PORT=4000 tidb=1 ARCONN=tidb bundle exec rake test:tidb
 
-  tidb523:
+  tidb524:
     if: ${{ !contains(github.event.commits[0].message, '[skip ci]') }}
     runs-on: ubuntu-latest
     services:
       tidb:
-        image: pingcap/tidb:v5.2.3
+        image: pingcap/tidb:v5.2.4
         env:
-          TIDB_VERSION: v5.2.3
+          TIDB_VERSION: v5.2.4
         ports: ["4000:4000"]
     steps:
     - uses: actions/checkout@v3
@@ -91,14 +91,14 @@ jobs:
     - run: sleep 30 && MYSQL_USER=root MYSQL_HOST=127.0.0.1 MYSQL_PORT=4000 tidb=1 ARCONN=tidb bundle exec rake db:tidb:build
     - run: sleep 10 && MYSQL_USER=root MYSQL_HOST=127.0.0.1 MYSQL_PORT=4000 tidb=1 ARCONN=tidb bundle exec rake test:tidb
 
-  tidb540:
+  tidb541:
     if: ${{ !contains(github.event.commits[0].message, '[skip ci]') }}
     runs-on: ubuntu-latest
     services:
       tidb:
-        image: pingcap/tidb:v5.4.0
+        image: pingcap/tidb:v5.4.1
         env:
-          TIDB_VERSION: v5.4.0
+          TIDB_VERSION: v5.4.1
         ports: ["4000:4000"]
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,4 +143,6 @@ jobs:
         ruby-version: 2.7
         bundler-cache: true
     - run: sleep 30 && MYSQL_USER=root MYSQL_HOST=127.0.0.1 MYSQL_PORT=4000 tidb=1 ARCONN=tidb bundle exec rake db:tidb:build
+    - run: mysql --host 127.0.0.1 --database activerecord_unittest --port 4000 -u root -e 'set @@global.tidb_enable_change_multi_schema = on'
+    - run: mysql --host 127.0.0.1 --database activerecord_unittest2 --port 4000 -u root -e 'set @@global.tidb_enable_change_multi_schema = on'
     - run: sleep 10 && MYSQL_USER=root MYSQL_HOST=127.0.0.1 MYSQL_PORT=4000 tidb=1 ARCONN=tidb bundle exec rake test:tidb

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,6 +89,8 @@ jobs:
         ruby-version: 2.7
         bundler-cache: true
     - run: sleep 30 && MYSQL_USER=root MYSQL_HOST=127.0.0.1 MYSQL_PORT=4000 tidb=1 ARCONN=tidb bundle exec rake db:tidb:build
+    - run: mysql --host 127.0.0.1 --database activerecord_unittest --port 4000 -u root -e 'set @@global.tidb_enable_change_multi_schema = on'
+    - run: mysql --host 127.0.0.1 --database activerecord_unittest2 --port 4000 -u root -e 'set @@global.tidb_enable_change_multi_schema = on'
     - run: sleep 10 && MYSQL_USER=root MYSQL_HOST=127.0.0.1 MYSQL_PORT=4000 tidb=1 ARCONN=tidb bundle exec rake test:tidb
 
   tidb541:
@@ -107,6 +109,8 @@ jobs:
         ruby-version: 2.7
         bundler-cache: true
     - run: sleep 30 && MYSQL_USER=root MYSQL_HOST=127.0.0.1 MYSQL_PORT=4000 tidb=1 ARCONN=tidb bundle exec rake db:tidb:build
+    - run: mysql --host 127.0.0.1 --database activerecord_unittest --port 4000 -u root -e 'set @@global.tidb_enable_change_multi_schema = on'
+    - run: mysql --host 127.0.0.1 --database activerecord_unittest2 --port 4000 -u root -e 'set @@global.tidb_enable_change_multi_schema = on'
     - run: sleep 10 && MYSQL_USER=root MYSQL_HOST=127.0.0.1 MYSQL_PORT=4000 tidb=1 ARCONN=tidb bundle exec rake test:tidb
 
   tidb600:
@@ -125,6 +129,8 @@ jobs:
         ruby-version: 2.7
         bundler-cache: true
     - run: sleep 30 && MYSQL_USER=root MYSQL_HOST=127.0.0.1 MYSQL_PORT=4000 tidb=1 ARCONN=tidb bundle exec rake db:tidb:build
+    - run: mysql --host 127.0.0.1 --database activerecord_unittest --port 4000 -u root -e 'set @@global.tidb_enable_change_multi_schema = on'
+    - run: mysql --host 127.0.0.1 --database activerecord_unittest2 --port 4000 -u root -e 'set @@global.tidb_enable_change_multi_schema = on'
     - run: sleep 10 && MYSQL_USER=root MYSQL_HOST=127.0.0.1 MYSQL_PORT=4000 tidb=1 ARCONN=tidb bundle exec rake test:tidb
 
   tidb610:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,24 +91,6 @@ jobs:
     - run: sleep 30 && MYSQL_USER=root MYSQL_HOST=127.0.0.1 MYSQL_PORT=4000 tidb=1 ARCONN=tidb bundle exec rake db:tidb:build
     - run: sleep 10 && MYSQL_USER=root MYSQL_HOST=127.0.0.1 MYSQL_PORT=4000 tidb=1 ARCONN=tidb bundle exec rake test:tidb
 
-  tidb531:
-    if: ${{ !contains(github.event.commits[0].message, '[skip ci]') }}
-    runs-on: ubuntu-latest
-    services:
-      tidb:
-        image: pingcap/tidb:v5.3.1
-        env:
-          TIDB_VERSION: v5.3.1
-        ports: ["4000:4000"]
-    steps:
-    - uses: actions/checkout@v2
-    - uses: ruby/setup-ruby@v1
-      with:
-        ruby-version: 2.7
-        bundler-cache: true
-    - run: sleep 30 && MYSQL_USER=root MYSQL_HOST=127.0.0.1 MYSQL_PORT=4000 tidb=1 ARCONN=tidb bundle exec rake db:tidb:build
-    - run: sleep 10 && MYSQL_USER=root MYSQL_HOST=127.0.0.1 MYSQL_PORT=4000 tidb=1 ARCONN=tidb bundle exec rake test:tidb
-
   tidb540:
     if: ${{ !contains(github.event.commits[0].message, '[skip ci]') }}
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,32 +17,14 @@ on:
       - 'docs/**'
 
 jobs:
-  tidb510:
+  tidb506:
     if: ${{ !contains(github.event.commits[0].message, '[skip ci]') }}
     runs-on: ubuntu-latest
     services:
       tidb:
-        image: hooopo/tidb-playground:v5.1.0
+        image: pingcap/tidb:v5.0.6
         env:
-          TIDB_VERSION: v5.1.0
-        ports: ["4000:4000"]
-    steps:
-    - uses: actions/checkout@v3
-    - uses: ruby/setup-ruby@v1
-      with:
-        ruby-version: 2.7
-        bundler-cache: true
-    - run: sleep 30 && MYSQL_USER=root MYSQL_HOST=127.0.0.1 MYSQL_PORT=4000 tidb=1 ARCONN=tidb bundle exec rake db:tidb:build
-    - run: sleep 10 && MYSQL_USER=root MYSQL_HOST=127.0.0.1 MYSQL_PORT=4000 tidb=1 ARCONN=tidb bundle exec rake test:tidb
-
-  tidb503:
-    if: ${{ !contains(github.event.commits[0].message, '[skip ci]') }}
-    runs-on: ubuntu-latest
-    services:
-      tidb:
-        image: hooopo/tidb-playground:v5.0.3
-        env:
-          TIDB_VERSION: v5.0.3
+          TIDB_VERSION: v5.0.6
         ports: ["4000:4000"]
     steps:
     - uses: actions/checkout@v3
@@ -55,14 +37,14 @@ jobs:
     - run: mysql --host 127.0.0.1 --database activerecord_unittest2 --port 4000 -u root -e 'set @@global.tidb_enable_change_column_type = 1'
     - run: sleep 10 && MYSQL_USER=root MYSQL_HOST=127.0.0.1 MYSQL_PORT=4000 tidb=1 ARCONN=tidb bundle exec rake test:tidb
 
-  tidb511:
+  tidb514:
     if: ${{ !contains(github.event.commits[0].message, '[skip ci]') }}
     runs-on: ubuntu-latest
     services:
       tidb:
-        image: hooopo/tidb-playground:v5.1.1
+        image: pingcap/tidb:v5.1.4
         env:
-          TIDB_VERSION: v5.1.1
+          TIDB_VERSION: v5.1.4
         ports: ["4000:4000"]
     steps:
     - uses: actions/checkout@v3
@@ -73,17 +55,89 @@ jobs:
     - run: sleep 30 && MYSQL_USER=root MYSQL_HOST=127.0.0.1 MYSQL_PORT=4000 tidb=1 ARCONN=tidb bundle exec rake db:tidb:build
     - run: sleep 10 && MYSQL_USER=root MYSQL_HOST=127.0.0.1 MYSQL_PORT=4000 tidb=1 ARCONN=tidb bundle exec rake test:tidb
 
-  tidb520:
+  tidb523:
     if: ${{ !contains(github.event.commits[0].message, '[skip ci]') }}
     runs-on: ubuntu-latest
     services:
       tidb:
-        image: hooopo/tidb-playground:v5.2.0
+        image: pingcap/tidb:v5.2.3
         env:
-          TIDB_VERSION: v5.2.0
+          TIDB_VERSION: v5.2.3
         ports: ["4000:4000"]
     steps:
     - uses: actions/checkout@v3
+    - uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: 2.7
+        bundler-cache: true
+    - run: sleep 30 && MYSQL_USER=root MYSQL_HOST=127.0.0.1 MYSQL_PORT=4000 tidb=1 ARCONN=tidb bundle exec rake db:tidb:build
+    - run: sleep 10 && MYSQL_USER=root MYSQL_HOST=127.0.0.1 MYSQL_PORT=4000 tidb=1 ARCONN=tidb bundle exec rake test:tidb
+
+  tidb531:
+    if: ${{ !contains(github.event.commits[0].message, '[skip ci]') }}
+    runs-on: ubuntu-latest
+    services:
+      tidb:
+        image: pingcap/tidb:v5.3.1
+        env:
+          TIDB_VERSION: v5.3.1
+        ports: ["4000:4000"]
+    steps:
+    - uses: actions/checkout@v3
+    - uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: 2.7
+        bundler-cache: true
+    - run: sleep 30 && MYSQL_USER=root MYSQL_HOST=127.0.0.1 MYSQL_PORT=4000 tidb=1 ARCONN=tidb bundle exec rake db:tidb:build
+    - run: sleep 10 && MYSQL_USER=root MYSQL_HOST=127.0.0.1 MYSQL_PORT=4000 tidb=1 ARCONN=tidb bundle exec rake test:tidb
+
+  tidb531:
+    if: ${{ !contains(github.event.commits[0].message, '[skip ci]') }}
+    runs-on: ubuntu-latest
+    services:
+      tidb:
+        image: pingcap/tidb:v5.3.1
+        env:
+          TIDB_VERSION: v5.3.1
+        ports: ["4000:4000"]
+    steps:
+    - uses: actions/checkout@v2
+    - uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: 2.7
+        bundler-cache: true
+    - run: sleep 30 && MYSQL_USER=root MYSQL_HOST=127.0.0.1 MYSQL_PORT=4000 tidb=1 ARCONN=tidb bundle exec rake db:tidb:build
+    - run: sleep 10 && MYSQL_USER=root MYSQL_HOST=127.0.0.1 MYSQL_PORT=4000 tidb=1 ARCONN=tidb bundle exec rake test:tidb
+
+  tidb540:
+    if: ${{ !contains(github.event.commits[0].message, '[skip ci]') }}
+    runs-on: ubuntu-latest
+    services:
+      tidb:
+        image: pingcap/tidb:v5.4.0
+        env:
+          TIDB_VERSION: v5.4.0
+        ports: ["4000:4000"]
+    steps:
+    - uses: actions/checkout@v2
+    - uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: 2.7
+        bundler-cache: true
+    - run: sleep 30 && MYSQL_USER=root MYSQL_HOST=127.0.0.1 MYSQL_PORT=4000 tidb=1 ARCONN=tidb bundle exec rake db:tidb:build
+    - run: sleep 10 && MYSQL_USER=root MYSQL_HOST=127.0.0.1 MYSQL_PORT=4000 tidb=1 ARCONN=tidb bundle exec rake test:tidb
+
+  tidb600:
+    if: ${{ !contains(github.event.commits[0].message, '[skip ci]') }}
+    runs-on: ubuntu-latest
+    services:
+      tidb:
+        image: pingcap/tidb:v6.0.0
+        env:
+          TIDB_VERSION: v6.0.0
+        ports: ["4000:4000"]
+    steps:
+    - uses: actions/checkout@v2
     - uses: ruby/setup-ruby@v1
       with:
         ruby-version: 2.7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,3 +144,21 @@ jobs:
         bundler-cache: true
     - run: sleep 30 && MYSQL_USER=root MYSQL_HOST=127.0.0.1 MYSQL_PORT=4000 tidb=1 ARCONN=tidb bundle exec rake db:tidb:build
     - run: sleep 10 && MYSQL_USER=root MYSQL_HOST=127.0.0.1 MYSQL_PORT=4000 tidb=1 ARCONN=tidb bundle exec rake test:tidb
+
+  tidb610:
+    if: ${{ !contains(github.event.commits[0].message, '[skip ci]') }}
+    runs-on: ubuntu-latest
+    services:
+      tidb:
+        image: pingcap/tidb:v6.1.0
+        env:
+          TIDB_VERSION: v6.1.0
+        ports: ["4000:4000"]
+    steps:
+    - uses: actions/checkout@v2
+    - uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: 2.7
+        bundler-cache: true
+    - run: sleep 30 && MYSQL_USER=root MYSQL_HOST=127.0.0.1 MYSQL_PORT=4000 tidb=1 ARCONN=tidb bundle exec rake db:tidb:build
+    - run: sleep 10 && MYSQL_USER=root MYSQL_HOST=127.0.0.1 MYSQL_PORT=4000 tidb=1 ARCONN=tidb bundle exec rake test:tidb

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,14 +17,32 @@ on:
       - 'docs/**'
 
 jobs:
-  tidb506:
+  tidb510:
     if: ${{ !contains(github.event.commits[0].message, '[skip ci]') }}
     runs-on: ubuntu-latest
     services:
       tidb:
-        image: pingcap/tidb:v5.0.6
+        image: hooopo/tidb-playground:v5.1.0
         env:
-          TIDB_VERSION: v5.0.6
+          TIDB_VERSION: v5.1.0
+        ports: ["4000:4000"]
+    steps:
+    - uses: actions/checkout@v3
+    - uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: 2.7
+        bundler-cache: true
+    - run: sleep 30 && MYSQL_USER=root MYSQL_HOST=127.0.0.1 MYSQL_PORT=4000 tidb=1 ARCONN=tidb bundle exec rake db:tidb:build
+    - run: sleep 10 && MYSQL_USER=root MYSQL_HOST=127.0.0.1 MYSQL_PORT=4000 tidb=1 ARCONN=tidb bundle exec rake test:tidb
+
+  tidb503:
+    if: ${{ !contains(github.event.commits[0].message, '[skip ci]') }}
+    runs-on: ubuntu-latest
+    services:
+      tidb:
+        image: hooopo/tidb-playground:v5.0.3
+        env:
+          TIDB_VERSION: v5.0.3
         ports: ["4000:4000"]
     steps:
     - uses: actions/checkout@v3
@@ -37,14 +55,14 @@ jobs:
     - run: mysql --host 127.0.0.1 --database activerecord_unittest2 --port 4000 -u root -e 'set @@global.tidb_enable_change_column_type = 1'
     - run: sleep 10 && MYSQL_USER=root MYSQL_HOST=127.0.0.1 MYSQL_PORT=4000 tidb=1 ARCONN=tidb bundle exec rake test:tidb
 
-  tidb514:
+  tidb511:
     if: ${{ !contains(github.event.commits[0].message, '[skip ci]') }}
     runs-on: ubuntu-latest
     services:
       tidb:
-        image: pingcap/tidb:v5.1.4
+        image: hooopo/tidb-playground:v5.1.1
         env:
-          TIDB_VERSION: v5.1.4
+          TIDB_VERSION: v5.1.1
         ports: ["4000:4000"]
     steps:
     - uses: actions/checkout@v3
@@ -55,14 +73,14 @@ jobs:
     - run: sleep 30 && MYSQL_USER=root MYSQL_HOST=127.0.0.1 MYSQL_PORT=4000 tidb=1 ARCONN=tidb bundle exec rake db:tidb:build
     - run: sleep 10 && MYSQL_USER=root MYSQL_HOST=127.0.0.1 MYSQL_PORT=4000 tidb=1 ARCONN=tidb bundle exec rake test:tidb
 
-  tidb524:
+  tidb520:
     if: ${{ !contains(github.event.commits[0].message, '[skip ci]') }}
     runs-on: ubuntu-latest
     services:
       tidb:
-        image: pingcap/tidb:v5.2.4
+        image: hooopo/tidb-playground:v5.2.0
         env:
-          TIDB_VERSION: v5.2.4
+          TIDB_VERSION: v5.2.0
         ports: ["4000:4000"]
     steps:
     - uses: actions/checkout@v3

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/pingcap/rails.git
-  revision: 8e88c0ecd838d642c542e8246a0b7c6e9df9c806
+  revision: 45f11ab0a2d19e82a4eff849970f7b36bf678b90
   branch: 7-0-stable
   specs:
     actioncable (7.0.2.3)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/pingcap/rails.git
-  revision: 45f11ab0a2d19e82a4eff849970f7b36bf678b90
+  revision: 43d2112caf6ad5b3c2256c1d3d8aac9282b60d29
   branch: 7-0-stable
   specs:
     actioncable (7.0.2.3)


### PR DESCRIPTION
This pull request uses the official `pingcap/tidb` Docker images for CI
- Run CI against the latest patch versions of each TiDB releases
- Add CI against TiDB v5.3.1, which was removed at https://github.com/pingcap/activerecord-tidb-adapter/pull/36
- Add CI against TiDB v5.4.0
- Order jobs based on TiDB versions from oldest to newest