### PR TITLE
Enable CI for 7-0-stable branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,12 +4,14 @@ on:
   push:
     branches:
       - main
+      - 7-0-stable
     paths-ignore:
       - 'README*.md'
       - 'docs/**'
   pull_request:
     branches:
       - main
+      - 7-0-stable
     paths-ignore:
       - 'README*.md'
       - 'docs/**'


### PR DESCRIPTION
This pull request enables CI for 7-0-stable branch. Please refer to https://github.com/pingcap/activerecord-tidb-adapter/pull/41#issuecomment-1083869079 for the background.