### PR TITLE
Active Record 7.0.1 or higher is required

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,8 @@ jobs:
     - uses: ruby/setup-ruby@v1
       with:
         ruby-version: 2.7
-        bundler-cache: true
+        bundler-cache: false
+    - run: bundle install
     - run: sleep 30 && MYSQL_USER=root MYSQL_HOST=127.0.0.1 MYSQL_PORT=4000 tidb=1 ARCONN=tidb bundle exec rake db:tidb:build
     - run: sleep 10 && MYSQL_USER=root MYSQL_HOST=127.0.0.1 MYSQL_PORT=4000 tidb=1 ARCONN=tidb bundle exec rake test:tidb
 
@@ -47,7 +48,8 @@ jobs:
     - uses: ruby/setup-ruby@v1
       with:
         ruby-version: 2.7
-        bundler-cache: true
+        bundler-cache: false
+    - run: bundle install
     - run: sleep 30 && MYSQL_USER=root MYSQL_HOST=127.0.0.1 MYSQL_PORT=4000 tidb=1 ARCONN=tidb bundle exec rake db:tidb:build
     - run: mysql --host 127.0.0.1 --database activerecord_unittest --port 4000 -u root -e 'set @@global.tidb_enable_change_column_type = 1'
     - run: mysql --host 127.0.0.1 --database activerecord_unittest2 --port 4000 -u root -e 'set @@global.tidb_enable_change_column_type = 1'
@@ -67,7 +69,8 @@ jobs:
     - uses: ruby/setup-ruby@v1
       with:
         ruby-version: 2.7
-        bundler-cache: true
+        bundler-cache: false
+    - run: bundle install
     - run: sleep 30 && MYSQL_USER=root MYSQL_HOST=127.0.0.1 MYSQL_PORT=4000 tidb=1 ARCONN=tidb bundle exec rake db:tidb:build
     - run: sleep 10 && MYSQL_USER=root MYSQL_HOST=127.0.0.1 MYSQL_PORT=4000 tidb=1 ARCONN=tidb bundle exec rake test:tidb
 
@@ -85,6 +88,7 @@ jobs:
     - uses: ruby/setup-ruby@v1
       with:
         ruby-version: 2.7
-        bundler-cache: true
+        bundler-cache: false
+    - run: bundle install
     - run: sleep 30 && MYSQL_USER=root MYSQL_HOST=127.0.0.1 MYSQL_PORT=4000 tidb=1 ARCONN=tidb bundle exec rake db:tidb:build
     - run: sleep 10 && MYSQL_USER=root MYSQL_HOST=127.0.0.1 MYSQL_PORT=4000 tidb=1 ARCONN=tidb bundle exec rake test:tidb

--- a/activerecord-tidb-adapter.gemspec
+++ b/activerecord-tidb-adapter.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'activerecord', '~> 7.0.0'
+  spec.add_dependency 'activerecord', '~> 7.0.1'
   spec.add_dependency 'mysql2'
 
   # Uncomment to register a new dependency of your gem


### PR DESCRIPTION
This pull request bumps the required Active Record version to 7.0.1 or higher
because of these two reasons:

- https://github.com/rails/rails/pull/44040 has been backported
to 7-0-stable branch via https://github.com/rails/rails/commit/bed85678aaa,
which is included in Rails 7.0.1 or higher

- Active Record TiDB adapter follows up https://github.com/rails/rails/pull/44040 change via https://github.com/pingcap/activerecord-tidb-adapter/pull/36/commits/12e5ef60af8fc4bf15cbfdf8fbab2439eddda14b

I do not think we need to support Rails 7.0.0 for now. 