### PR TITLE
Change the workflow name to "CI" to make the status badge "passing"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: activerecord-tidb-adapter main
+name: CI
 
 on:
   push:


### PR DESCRIPTION
This pull request aims to make the GitHub Actions badge "passing". As of right now it says "no status":

![Screen Shot 2022-04-08 at 16 09 33](https://user-images.githubusercontent.com/73684/162383227-4458086a-586a-4406-82b1-cc381c058b69.png)

Investigated this issue and found https://github.community/t/badge-shows-no-status-and-no-status-mismatch-between-the-filepath-vs-name-usage/16907 which suggests to add the workflow name.

We actually have the workflow name "activerecord-tidb-adapter main" but it does not look like this name is handled correctly because the workflow name is ".github/workflows/ci.yml", not "activerecord-tidb-adapter main".

![Screen Shot 2022-04-08 at 16 09 46](https://user-images.githubusercontent.com/73684/162383440-11732bc3-7a87-451b-ace5-9c517ab6ecea.png)

This pull request changes the workflow name to "CI", which would contribute to make the badge status green.